### PR TITLE
Add ability to show newly added plugins in the marketplace

### DIFF
--- a/FORK_README.md
+++ b/FORK_README.md
@@ -1,1 +1,6 @@
 This is a fork of the official LogSeq repo.
+
+## Changes added in the fork
+
+### Plugins
+* [#1](https://github.com/katafrakt/logseq/pull/1) Add option to sort plugins in the marketplace by added date, to explose newly created ones

--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -576,7 +576,11 @@
 
             {:title   (t :plugin/title "A - Z")
              :options {:on-click #(reset! *sort-by :letters)}
-             :icon    (ui/icon (aim-icon :letters))}])
+             :icon    (ui/icon (aim-icon :letters))}
+
+            {:title   (t :plugin/date-added)
+             :options {:on-click #(reset! *sort-by :date-added)}
+             :icon    (ui/icon (aim-icon :date-added))}])
          {}))
 
       ;; more - updater
@@ -652,7 +656,7 @@
     (rum/local false ::fetching)
     (rum/local "" ::search-key)
     (rum/local :plugins ::category)
-    (rum/local :downloads ::sort-by)                        ;; downloads / stars / letters / updates
+    (rum/local :downloads ::sort-by)                        ;; downloads / stars / letters / updates / date-added
     (rum/local :default ::filter-by)
     (rum/local nil ::error)
     (rum/local nil ::cached-query-flag)

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -584,6 +584,7 @@
  :plugin/uninstall "Uninstall"
  :plugin/marketplace "Marketplace"
  :plugin/downloads "Downloads"
+ :plugin/date-added "Newly added"
  :plugin/stars "Stars"
  :plugin/title "Title ({1})"
  :plugin/all "All"


### PR DESCRIPTION
This is good for discoverability.

<img width="1345" alt="Screenshot 2024-12-11 at 16 22 22" src="https://github.com/user-attachments/assets/eff17a45-7750-4458-8bf0-5341fef3fdf4" />
