### PR TITLE
Fix pasting of X/Twitter links

### DIFF
--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -52,7 +52,8 @@
     (boolean (text-util/get-matched-video url))
     (util/format "{{video %s}}" url)
 
-    (or (string/includes? url "twitter.com") (string/includes? url "x.com"))
+    (or (re-matches #"^https://twitter\.com.*?$" url)
+           (re-matches #"^https://x\.com.*?$" url))
     (util/format "{{twitter %s}}" url)))
 
 (defn- try-parse-as-json


### PR DESCRIPTION
There was a bug that pasting link from domains ending with x.com was
parsed as a ex-Twitter link. But this was not necessarily a link from
this social network. This commit changes the regex to better detect
proper X links and tell them apart from non-X links.

This is a port of an original PR logseq#11942